### PR TITLE
Ease of use changes to readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ---
 This program generates a .mp4 video automatically by querying the top post on the
 r/askreddit subreddit, and grabbing several comments. To use this program:
-- [ ] Install dependencies ```pip install bs4 markdown markdown_to_text moviepy praw pyttsx3 selenium videoscript```
+- [ ] Install dependencies ```pip install bs4 markdown markdown_to_text moviepy praw pyttsx3 selenium ```
 - [ ] Register with Reddit to create and API application [here](https://www.reddit.com/prefs/apps/)
 - [ ] Use the credentials from the previous step to update reddit.py line 46-51
 - [ ] Make a copy of config.example.ini and rename to config.ini

--- a/README.md
+++ b/README.md
@@ -7,10 +7,11 @@
 ---
 This program generates a .mp4 video automatically by querying the top post on the
 r/askreddit subreddit, and grabbing several comments. To use this program:
-- [ ] Install dependencies
+- [ ] Install dependencies ```pip install bs4 markdown markdown_to_text moviepy praw pyttsx3 selenium videoscript```
 - [ ] Register with Reddit to create and API application [here](https://www.reddit.com/prefs/apps/)
 - [ ] Use the credentials from the previous step to update reddit.py line 46-51
 - [ ] Make a copy of config.example.ini and rename to config.ini
 
 Now, you can run `python main.py` to be prompted for which post to choose. Alternatively,
 you can run `python main.py <reddit-post-id>` to create a video for a specific post.
+For Mac and Linux users, change the `python` to `python3` for version specification 


### PR DESCRIPTION
added the pip one-liner for all none standard libraries I could find.

The following libraries are part of the Python standard library:

configparser
datetime
math
os
random
re
subprocess
sys
time
The following libraries are not part of the standard library:

bs4
markdown
markdown_to_text
moviepy
praw
pyttsx3
selenium
videoscript - custom
voiceover -custom made